### PR TITLE
add smarty plugin to trim tags

### DIFF
--- a/app/plugins/modifier.trim_exclude.php
+++ b/app/plugins/modifier.trim_exclude.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Smarty modifier to trim/strip every HTML tag coming from a String,  except the ones given. 
+ * @param array $tags parameters
+ * @return string with trimmed tags
+ */
+/**
+ * Type:     modifier<br>
+ * Name:     trim_exclude<br>
+ */
+function smarty_modifier_trim_exclude()
+{
+    // the tags to exclude
+    $tags=func_get_args();
+    if (!isset($tags[1])) $tags[1] = true;
+    if ($tags[1] === true) {
+      // search and replace 
+      return preg_replace('!<[^>]*?>!', ' ', $tags[0]);
+    } else {
+      // allow them
+      if (is_string($tags[1])) $allowable_tags = strtr($tags[1],'[]','<>');}
+    return strip_tags($tags[0],$allowable_tags);
+}


### PR DESCRIPTION
It is imperative for the tecnologia service to try and save as much bandwidth
consumption as possible. What this plugin does is that it removes
every HTML tag that is not an exception. Posts usually come with [p], [a], [ul], [li] and [strong] tags, and we're not interested in the other stuff, at least on the main page. This fixes that problem.