### PR TITLE
Remove LAB Miami address from our spanish landing

### DIFF
--- a/app/views/index/bienvenido.phtml
+++ b/app/views/index/bienvenido.phtml
@@ -589,7 +589,7 @@
 
 	<!-- Map -->
 	<section id="contact" class="map">
-		<img style="width:100%;" src="<?php echo $wwwhttp; ?>/images/map.png" alt="We are located at The LAB Miami"/>
+		<img style="width:100%;" src="<?php echo $wwwhttp; ?>/images/map.png" alt="Estamos ubicados en el Miami Entrepreneurship Center"/>
 	</section>
 
 	<!-- Footer -->
@@ -599,8 +599,8 @@
 				<div class="col-xs-12 text-center">
 					<h1>Cont&aacute;ctanos</h1>
 					<hr class="small">
-					<p><b>Apretaste</b>, ubicado en The LAB Miami</p>
-					<p>400 Northwest 26th Street<br>Miami, FL 33127</p>
+					<p><b>Apretaste</b>, ubicado en el Miami Entrepreneurship Center</p>
+					<p>261 NE 1st Street, 5th Floor<br>Miami, FL 33132</p>
 					<ul class="list-unstyled">
 						<li><i class="fa fa-phone fa-fw"></i> (305) 457-1656</li>
 						<li><i class="fa fa-envelope-o fa-fw"></i>  <a href="mailto:support@apretaste.com">support@apretaste.com</a></li>


### PR DESCRIPTION
This updates our actual address on the spanish landing page.